### PR TITLE
update from upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "leetcode"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.60.0"
 authors = ["Kristof Mattei"]
 license-file = "LICENSE"
 description = "Leet Code"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.59.0"
+channel = "1.60.0"
 components = [ "cargo", "clippy", "rustfmt"  ]
 profile = "minimal"

--- a/src/problem_0031/mod.rs
+++ b/src/problem_0031/mod.rs
@@ -1,6 +1,6 @@
 use crate::shared::Solution;
 
-fn next_permutation(nums: &mut Vec<i32>) {
+fn next_permutation(nums: &mut [i32]) {
     let mut max_index = 0;
 
     // find the first index of a number where the number before it is lower than the current
@@ -46,6 +46,7 @@ fn next_permutation(nums: &mut Vec<i32>) {
 }
 
 impl Solution {
+    #[allow(clippy::ptr_arg)]
     pub fn next_permutation(nums: &mut Vec<i32>) {
         next_permutation(nums);
     }

--- a/src/problem_0048/mod.rs
+++ b/src/problem_0048/mod.rs
@@ -1,6 +1,6 @@
 use crate::shared::Solution;
 
-fn swap(matrix: &mut Vec<Vec<i32>>, r1c1: (usize, usize), r2c2: (usize, usize)) {
+fn swap(matrix: &mut [Vec<i32>], r1c1: (usize, usize), r2c2: (usize, usize)) {
     match r1c1.0.cmp(&r2c2.0) {
         std::cmp::Ordering::Equal => {
             matrix[r1c1.0].swap(r1c1.1, r2c2.1);
@@ -15,7 +15,7 @@ fn swap(matrix: &mut Vec<Vec<i32>>, r1c1: (usize, usize), r2c2: (usize, usize)) 
 }
 
 fn swap_ord(
-    matrix: &mut Vec<Vec<i32>>,
+    matrix: &mut [Vec<i32>],
     low_row_coordinates: (usize, usize),
     high_row_coordinates: (usize, usize),
 ) {
@@ -26,7 +26,7 @@ fn swap_ord(
     );
 }
 
-fn rotate(matrix: &mut Vec<Vec<i32>>) {
+fn rotate(matrix: &mut [Vec<i32>]) {
     let n = matrix.len();
 
     for x in 0..n / 2 {
@@ -41,6 +41,7 @@ fn rotate(matrix: &mut Vec<Vec<i32>>) {
 }
 
 impl Solution {
+    #[allow(clippy::ptr_arg)]
     pub fn rotate(matrix: &mut Vec<Vec<i32>>) {
         rotate(matrix);
     }

--- a/src/problem_0073/mod.rs
+++ b/src/problem_0073/mod.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::shared::Solution;
 
-fn set_zeroes(matrix: &mut Vec<Vec<i32>>) {
+fn set_zeroes(matrix: &mut [Vec<i32>]) {
     let mut rows_to_zero = HashSet::new();
     let mut cols_to_zero = HashSet::new();
 
@@ -26,6 +26,7 @@ fn set_zeroes(matrix: &mut Vec<Vec<i32>>) {
 }
 
 impl Solution {
+    #[allow(clippy::ptr_arg)]
     pub fn set_zeroes(matrix: &mut Vec<Vec<i32>>) {
         set_zeroes(matrix);
     }

--- a/src/problem_0075/mod.rs
+++ b/src/problem_0075/mod.rs
@@ -1,6 +1,6 @@
 use crate::shared::Solution;
 
-fn sort_colors(nums: &mut Vec<i32>) {
+fn sort_colors(nums: &mut [i32]) {
     let mut arr: [usize; 3] = [0; 3];
 
     for n in nums.iter() {
@@ -25,6 +25,7 @@ fn sort_colors(nums: &mut Vec<i32>) {
 }
 
 impl Solution {
+    #[allow(clippy::ptr_arg)]
     pub fn sort_colors(nums: &mut Vec<i32>) {
         sort_colors(nums);
     }

--- a/src/problem_0088/mod.rs
+++ b/src/problem_0088/mod.rs
@@ -1,6 +1,6 @@
 use crate::shared::Solution;
 
-fn merge(nums1: &mut Vec<i32>, m: usize, nums2: &mut Vec<i32>, n: usize) {
+fn merge(nums1: &mut [i32], m: usize, nums2: &mut [i32], n: usize) {
     (&mut nums1[m..m + n]).copy_from_slice(nums2);
 
     for i in m..m + n {
@@ -20,7 +20,7 @@ fn merge(nums1: &mut Vec<i32>, m: usize, nums2: &mut Vec<i32>, n: usize) {
 }
 
 impl Solution {
-    pub fn merge2(nums1: &mut Vec<i32>, m: i32, nums2: &mut Vec<i32>, n: i32) {
+    pub fn merge2(nums1: &mut [i32], m: i32, nums2: &mut [i32], n: i32) {
         merge(nums1, m as usize, nums2, n as usize);
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -79,7 +79,7 @@ where
     true
 }
 
-pub fn sort_vec_of_vec<T>(vec: &mut Vec<Vec<T>>)
+pub fn sort_vec_of_vec<T>(vec: &mut [Vec<T>])
 where
     T: std::cmp::Ord,
 {


### PR DESCRIPTION
- chore(deps): bump rust from `fea2328` to `cab550a`
- chore(deps-dev): bump @semantic-release/github from 8.0.2 to 8.0.4
- chore(deps): bump actions/cache from 3.0.0 to 3.0.1
- chore(deps): bump rust from `cab550a` to `db2731e`
- chore(deps): bump rust from `db2731e` to `7c0ea3e`
- chore(deps): bump actions/setup-node from 3.0.0 to 3.1.0
- chore(deps-dev): bump prettier from 2.6.1 to 2.6.2
- chore(deps): bump alpine from 3.15.3 to 3.15.4
- chore(deps): bump codecov/codecov-action from 2.1.0 to 3
- chore(deps): bump minimist from 1.2.5 to 1.2.6
- chore(deps): bump docker/metadata-action from 3.6.2 to 3.7.0
- chore(deps-dev): bump semver from 7.3.5 to 7.3.6
- feat: rust 1.60.0
