### PR TITLE
update from upstream

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "leetcode",
   "version": "0.0.0-development",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "ISC",
       "devDependencies": {
-        "prettier": "^2.7.1"
+        "prettier": "^2.8.2"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -30,14 +30,6 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
-    }
-  },
-  "dependencies": {
-    "prettier": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
-      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/kristof-mattei/leetcode#readme",
   "devDependencies": {
-    "prettier": "^2.7.1"
+    "prettier": "^2.8.2"
   },
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
- chore(deps): update actions-rs-plus/clippy-check digest to 527fa76
- chore(deps): update returntocorp/semgrep docker digest to 4569a84
- chore(deps): update mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye docker digest to 95d642e
- chore(deps): update actions-rs-plus/clippy-check digest to 629582b
- chore(deps): update actions-rs-plus/clippy-check digest to f3ff555
- chore(deps): update rust:1.66.0 docker digest to 4da0fa2
- chore(deps): update rust:1.66.0 docker digest to 3d66c18
- chore(deps): update actions/cache action to v3.2.0
- chore(deps): update rust:1.66.0 docker digest to 0067330
- chore(deps): update actions/cache action to v3.2.1
- chore(deps): lock file maintenance
- chore(deps): update actions-rs-plus/clippy-check digest to b1697fd
- chore(deps): update actions/cache action to v3.2.2
- chore(deps): update actions-rs-plus/clippy-check digest to d315872
- chore(deps): lock file maintenance
- chore(deps): update actions-rs-plus/clippy-check digest to b21d496
- chore(deps): update actions-rs-plus/clippy-check digest to 6f0b6d8
- chore(deps): update returntocorp/semgrep docker digest to c71f3f2
- chore(deps): update actions/checkout action to v3.3.0
- chore(deps): update actions-rs-plus/clippy-check digest to d508503
- chore(deps): update actions/download-artifact action to v3.0.2
- chore(deps): update actions/setup-node action to v3.6.0
- chore(deps): update actions/upload-artifact action to v3.1.2
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.3.0
- chore(deps): lock file maintenance
- chore(deps): update actions/cache action to v3.2.3
- chore(deps): update alpine docker tag to v3.17.1
- chore(deps): update actions-rs-plus/clippy-check digest to 6000cd3
- chore(deps): update actions-rs-plus/clippy-check digest to cbcfbff
- chore: node v18
- chore(deps): update dependency semantic-release to v20
- chore(deps): update rust:1.66.0 docker digest to 1e82d23
- chore(deps): update docker/metadata-action action to v4.2.0
- chore(deps): update rust:1.66.0 docker digest to 5a051df
- fix: use cocogitto bump, and support no new version generated
- chore(deps): update mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye docker digest to fd916e6
- chore(deps): update rust:1.66.0 docker digest to 7d80aa9
- fix: prevent cog throwing an error which causes script termination
- chore(deps): update rust to v1.66.1
