### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,12 +308,11 @@ jobs:
         run: |
           grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@95b1a2355bd0e526ad2fd62da9fd386ad4c98474 # v2.2.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: reports
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: reports/lcov.info
 
       - name: Fail if tests failed
         shell: bash

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,8 +18,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "leetcode=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,leetcode=trace"
             }
         },
         {
@@ -41,8 +41,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "leetcode=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,leetcode=trace"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "cargo",
             "command": "build",
-            "args": [],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.1.tgz",
+      "integrity": "sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==",
       "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
@@ -199,9 +199,9 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
+      "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
       "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
@@ -227,19 +227,19 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
-      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.2.0.tgz",
+      "integrity": "sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==",
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.1.2.tgz",
-      "integrity": "sha512-Jx8KuKqEAVRsK6fMzZKv3h6UH9/NRDHsDRtUAROqqmZlCptM///Uef7A1ViZ/cbDplekz7VbDWdFLAZ/mpuDww==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
+      "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
       "dev": true,
       "dependencies": {
-        "@octokit/tsconfig": "^2.0.0",
-        "@octokit/types": "^9.3.2"
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
       },
       "engines": {
         "node": ">= 18"
@@ -249,13 +249,12 @@
       }
     },
     "node_modules/@octokit/plugin-retry": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.5.tgz",
-      "integrity": "sha512-sB1RWMhSrre02Atv95K6bhESlJ/sPdZkK/wE/w1IdSCe0yM6FxSjksLa6T7aAvxvxlLKzQEC4KIiqpqyov1Tbg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.2.tgz",
+      "integrity": "sha512-/Z7rWLCfjwmaVdyFuMkZoAnhfrvYgtvDrbO2d6lv7XrvJa8gFGB5tLUMngfuyMBfDCc5B9+EVu7IkQx5ebVlMg==",
       "dev": true,
       "dependencies": {
-        "@octokit/request-error": "^4.0.1",
-        "@octokit/types": "^10.0.0",
+        "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
@@ -265,33 +264,10 @@
         "@octokit/core": ">=3"
       }
     },
-    "node_modules/@octokit/plugin-retry/node_modules/@octokit/request-error": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-4.0.2.tgz",
-      "integrity": "sha512-uqwUEmZw3x4I9DGYq9fODVAAvcLsPQv97NRycP6syEFu5916M189VnNBW2zANNwqg3OiligNcAey7P0SET843w==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^10.0.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
-      }
-    },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.1.0.tgz",
-      "integrity": "sha512-JqMbTiPC0sUSTsLQsdq3JVx1mx8UtTo5mwR80YqPXE93+XhevvSyOR1rO2Z+NbO/r0TK4hqFJSSi/9oIZBxZTg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.1.tgz",
+      "integrity": "sha512-C5h2lT+LEF4SqmbB1RbMn1PhBlHKkZoqMGS39woJr0XJ+getmOcUvrytTtS4NOn1zh/iT1ByRWYwwmFYznv83w==",
       "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
@@ -305,9 +281,9 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.5.tgz",
+      "integrity": "sha512-z83E8UIlPNaJUsXpjD8E0V5o/5f+vJJNbNcBwVZsX3/vC650U41cOkTLjq4PKk9BYonQGOnx7N17gvLyNjgGcQ==",
       "dev": true,
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
@@ -336,18 +312,18 @@
       }
     },
     "node_modules/@octokit/tsconfig": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-2.0.0.tgz",
-      "integrity": "sha512-tWnrai3quGt8+gRN2edzo9fmraWekeryXPeXDomMw2oFSpu/lH3VSWGn/q4V+rwjTRMeeXk/ci623/01Zet4VQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==",
       "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.3.tgz",
+      "integrity": "sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==",
       "dev": true,
       "dependencies": {
-        "@octokit/openapi-types": "^18.0.0"
+        "@octokit/openapi-types": "^17.2.0"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -378,9 +354,9 @@
       "dev": true
     },
     "node_modules/@pnpm/npm-conf": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
-      "integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.0.tgz",
+      "integrity": "sha512-roLI1ul/GwzwcfcVpZYPdrgW2W/drLriObl1h+yLF5syc8/5ULWw2ALbCHUWF+4YltIqA3xFSbG4IwyJz37e9g==",
       "dev": true,
       "dependencies": {
         "@pnpm/config.env-replace": "^1.1.0",
@@ -534,12 +510,12 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.4.tgz",
-      "integrity": "sha512-6R3timIQ7VoL2QWRkc9DG8v74RQtRp7UOe/2KbNaqwJ815qOibAv65bH3RtTEhs4axEaHoZf7HDgFs5opaZ9Jw==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.3.tgz",
+      "integrity": "sha512-Chbv3kX4o+y+r1X6hsqBVB8NFbSVfiNlYOqMG6o9Wc8r5Y4cjxfbaMCuJ++XAtw3YXYX/NVD05cPzBi4Orjusg==",
       "dev": true,
       "dependencies": {
-        "@semantic-release/error": "^4.0.0",
+        "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^4.0.1",
         "execa": "^7.0.0",
         "fs-extra": "^11.0.0",
@@ -558,15 +534,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
@@ -701,9 +668,9 @@
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.0.tgz",
-      "integrity": "sha512-Gur3yQGM9qiLNs0KPP7LPgeRbio2QTt4xXouobMCarR0/wyW3F+F/+OWwshg3NG0Adon7uQfSZBpB46NfhoF1A==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.11.1.tgz",
+      "integrity": "sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
@@ -950,9 +917,9 @@
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
-      "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.0.tgz",
+      "integrity": "sha512-8PyWTnn7zBIt9l4hj4UusFs1TyG+9Ulu1zlOAc72L7Sdv9Hsc8E86ot7htY3HXCVhXHB/NO0pVGvZpwsyJvFfw==",
       "dev": true,
       "dependencies": {
         "conventional-commits-filter": "^3.0.0",
@@ -960,7 +927,7 @@
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
         "meow": "^8.1.2",
-        "semver": "^7.0.0",
+        "semver": "^6.3.0",
         "split": "^1.0.1"
       },
       "bin": {
@@ -968,6 +935,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/conventional-commits-filter": {
@@ -1023,36 +999,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/d-fischer"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "node_modules/cosmiconfig/node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
-    "node_modules/cosmiconfig/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cross-spawn": {
@@ -1211,9 +1157,9 @@
       "dev": true
     },
     "node_modules/env-ci": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-9.1.1.tgz",
-      "integrity": "sha512-Im2yEWeF4b2RAMAaWvGioXk6m0UNaIjD8hj28j2ij5ldnIFrDQT0+pzDvpbRkcjurhXhf/AsBKv8P2rtmGi9Aw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-9.1.0.tgz",
+      "integrity": "sha512-ZCEas2sDVFR3gpumwwzSU4OJZwWJ46yqJH3TqH3vSxEBzeAlC0uCJLGAnZC0vX1TIXzHzjcwpKmUn2xw5mC/qA==",
       "dev": true,
       "dependencies": {
         "execa": "^7.0.0",
@@ -1299,9 +1245,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1434,9 +1380,9 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-      "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.0.tgz",
+      "integrity": "sha512-ql6FW5b8tgMYvI4UaoxG3EQN3VyZ6VeQpxNBGg5BZ4xD4u+HJeprzhMMA4OCBEGQgSR+m87pstWMpiVW64W8Fw==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -1481,14 +1427,14 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
       "dev": true,
       "dependencies": {
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^4.0.0"
       },
@@ -1880,13 +1826,10 @@
       "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
-      "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
-      "dev": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -1941,13 +1884,10 @@
       }
     },
     "node_modules/lines-and-columns": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
-      "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -2097,9 +2037,9 @@
       }
     },
     "node_modules/marked-terminal/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -2152,18 +2092,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/meow/node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "node_modules/meow/node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
-    },
     "node_modules/meow/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2201,24 +2129,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/meow/node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/path-exists": {
@@ -2422,9 +2332,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -2469,9 +2379,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.0.tgz",
-      "integrity": "sha512-AXeiBAdfM5K2jvBwA7EGLKeYyt0VnhmJRnlq4k2+M0Ao9v7yKJBqF8xFPzQL8kAybzwlfpTPCZwM4uTIszb3xA==",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.7.1.tgz",
+      "integrity": "sha512-kxMviaiLX4Lfnjy2dt7EWB87v5QdLiGpy04S2ORdKLmPqFhgy8g4cgJjQfnWob4mJIaNHjBO+hk45CvLlsZZ8g==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2531,7 +2441,6 @@
         "semver",
         "sigstore",
         "ssri",
-        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
@@ -2543,14 +2452,14 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^6.3.0",
-        "@npmcli/config": "^6.2.1",
+        "@npmcli/arborist": "^6.2.9",
+        "@npmcli/config": "^6.2.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/package-json": "^3.1.1",
         "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^17.1.3",
+        "cacache": "^17.1.2",
         "chalk": "^5.2.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
@@ -2558,21 +2467,21 @@
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.2",
-        "glob": "^10.2.7",
+        "glob": "^10.2.4",
         "graceful-fs": "^4.2.11",
         "hosted-git-info": "^6.1.1",
-        "ini": "^4.1.1",
+        "ini": "^4.1.0",
         "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
-        "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.2",
-        "libnpmfund": "^4.0.19",
+        "libnpmdiff": "^5.0.17",
+        "libnpmexec": "^6.0.0",
+        "libnpmfund": "^4.0.17",
         "libnpmhook": "^9.0.3",
         "libnpmorg": "^5.0.4",
-        "libnpmpack": "^5.0.19",
-        "libnpmpublish": "^7.5.0",
+        "libnpmpack": "^5.0.17",
+        "libnpmpublish": "^7.3.0",
         "libnpmsearch": "^6.0.2",
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
@@ -2581,8 +2490,8 @@
         "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^9.4.0",
-        "nopt": "^7.2.0",
+        "node-gyp": "^9.3.1",
+        "nopt": "^7.1.0",
         "npm-audit-report": "^5.0.0",
         "npm-install-checks": "^6.1.1",
         "npm-package-arg": "^10.1.0",
@@ -2592,16 +2501,15 @@
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^15.2.0",
+        "pacote": "^15.1.3",
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
-        "semver": "^7.5.2",
-        "sigstore": "^1.7.0",
+        "semver": "^7.5.1",
+        "sigstore": "^1.5.0",
         "ssri": "^10.0.4",
-        "supports-color": "^9.3.1",
-        "tar": "^6.1.15",
+        "tar": "^6.1.14",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
@@ -2653,6 +2561,12 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2707,7 +2621,7 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2728,7 +2642,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "6.3.0",
+      "version": "6.2.9",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2740,7 +2654,7 @@
         "@npmcli/metavuln-calculator": "^5.0.0",
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/package-json": "^3.0.0",
         "@npmcli/query": "^3.0.0",
         "@npmcli/run-script": "^6.0.0",
         "bin-links": "^4.0.1",
@@ -2775,13 +2689,12 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "6.2.1",
+      "version": "6.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/map-workspaces": "^3.0.2",
-        "ci-info": "^3.8.0",
         "ini": "^4.1.0",
         "nopt": "^7.0.0",
         "proc-log": "^3.0.0",
@@ -2882,6 +2795,19 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "2.0.0",
       "dev": true,
@@ -2901,7 +2827,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "4.0.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2972,19 +2898,6 @@
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.1.0",
-        "tuf-js": "^1.1.7"
-      },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -3222,7 +3135,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "17.1.3",
+      "version": "17.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3560,12 +3473,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "dev": true,
@@ -3635,15 +3542,15 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.2.7",
+      "version": "10.2.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2",
+        "minimatch": "^9.0.0",
+        "minipass": "^5.0.0 || ^6.0.0",
         "path-scurry": "^1.7.0"
       },
       "bin": {
@@ -3797,6 +3704,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -3814,7 +3727,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "4.1.1",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3868,7 +3781,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.12.1",
+      "version": "2.12.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3901,7 +3814,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
-      "version": "2.2.1",
+      "version": "2.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -3971,12 +3884,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "5.0.19",
+      "version": "5.0.17",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.3.0",
+        "@npmcli/arborist": "^6.2.9",
         "@npmcli/disparity-colors": "^3.0.0",
         "@npmcli/installed-package-contents": "^2.0.2",
         "binary-extensions": "^2.2.0",
@@ -3991,12 +3904,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "6.0.2",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.3.0",
+        "@npmcli/arborist": "^6.2.9",
         "@npmcli/run-script": "^6.0.0",
         "ci-info": "^3.7.1",
         "npm-package-arg": "^10.1.0",
@@ -4013,12 +3926,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "4.0.19",
+      "version": "4.0.17",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.3.0"
+        "@npmcli/arborist": "^6.2.9"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -4051,12 +3964,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "5.0.19",
+      "version": "5.0.17",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^6.3.0",
+        "@npmcli/arborist": "^6.2.9",
         "@npmcli/run-script": "^6.0.0",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.8"
@@ -4066,7 +3979,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "7.5.0",
+      "version": "7.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4161,7 +4074,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.1",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4381,16 +4294,15 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.4.0",
+      "version": "9.3.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^11.0.3",
+        "make-fetch-happen": "^10.0.3",
         "nopt": "^6.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
@@ -4403,6 +4315,19 @@
       },
       "engines": {
         "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
@@ -4432,6 +4357,87 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
+      "version": "16.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
@@ -4473,6 +4479,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -4483,6 +4516,35 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
+      "version": "3.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
@@ -4535,6 +4597,42 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/ssri": {
+      "version": "9.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/unique-filename": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/unique-slug": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/npm/node_modules/node-gyp/node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -4551,7 +4649,7 @@
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "7.2.0",
+      "version": "7.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4744,7 +4842,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "15.2.0",
+      "version": "15.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4808,13 +4906,13 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.9.2",
+      "version": "1.9.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
+        "minipass": "^5.0.0 || ^6.0.0"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4942,7 +5040,7 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "6.0.4",
+      "version": "6.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5051,22 +5149,8 @@
       }
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
+      "version": "5.1.2",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -5078,7 +5162,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.2",
+      "version": "7.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5144,14 +5228,14 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "1.7.0",
+      "version": "1.5.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/protobuf-specs": "^0.1.0",
-        "@sigstore/tuf": "^1.0.1",
-        "make-fetch-happen": "^11.0.1"
+        "make-fetch-happen": "^11.0.1",
+        "tuf-js": "^1.1.3"
       },
       "bin": {
         "sigstore": "bin/sigstore.js"
@@ -5243,12 +5327,12 @@
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
+      "version": "1.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
@@ -5305,20 +5389,8 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "9.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.15",
+      "version": "6.1.14",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5380,14 +5452,14 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "1.1.7",
+      "version": "1.1.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@tufjs/models": "1.0.4",
         "debug": "^4.3.4",
-        "make-fetch-happen": "^11.1.1"
+        "make-fetch-happen": "^11.1.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5567,7 +5639,7 @@
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5800,31 +5872,18 @@
       }
     },
     "node_modules/parse-json": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
-      "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "error-ex": "^1.3.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "lines-and-columns": "^2.0.3",
-        "type-fest": "^3.8.0"
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse-json/node_modules/type-fest": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.0.tgz",
-      "integrity": "sha512-Gur3yQGM9qiLNs0KPP7LPgeRbio2QTt4xXouobMCarR0/wyW3F+F/+OWwshg3NG0Adon7uQfSZBpB46NfhoF1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6094,6 +6153,24 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/read-pkg/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
+      "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/lines-and-columns": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
+      "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/read-pkg/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -6116,6 +6193,25 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/parse-json": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
+      "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "lines-and-columns": "^2.0.3",
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+NEW_NAME=$1
+
+FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
+
+
+echo "New name = ${NEW_NAME}"
+
+
+if [[ ${#FILTERED_NAME} != 0 ]]; then
+    echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
+    exit 1
+fi
+
+
+NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
+
+echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
+
+
+P1="rust-end-to-end-"
+OLD_NAME="${P1}application"
+OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
+
+echo ${OLD_NAME_WITH_UNDERSCORE}
+
+
+rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE} | xargs -i sed -i "s/${OLD_NAME_WITH_UNDERSCORE}/${NEW_NAME_WITH_UNDERSCORE}/g" {}


### PR DESCRIPTION
- feat: problem 10
- fix: to lib
- fix: centralized solution
- feat: problem 12
- feat: problem 13
- feat: problem 14
- feat: problem 15
- feat: problem 16
- feat: problem 17
- feat: problem 18
- fix: cleanup
- chore: formatting
- chore(deps): bump EnricoMi/publish-unit-test-result-action
- feat: problem 20
- feat: problem 21
- feat: problem 22
- feat: problem 23
- feat: problem 24
- chore: problem 25 foundation
- chore(deps): bump actions/setup-node from 2.5.1 to 3.0.0
- feat: problem 25
- chore: remove commented code
- chore: rust 1.59.0
- feat: problem 28
- chore(deps): bump EnricoMi/publish-unit-test-result-action
- feat: problem 29
- feat: problem 30
- feat: problem 31
- chore: problem 32 wip
- feat: problem 32
- chore: problem 33 wip
- feat: problem 33
- chore: problem 34 wip
- chore: problem 34 wip
- feat: problem 34
- chore: problem 35 wip
- feat: problem 35
- feat: problem 36
- chore: problem 37 wip
- feat: problem 37
- feat: problem 37 cont
- feat: problem 37
- feat: problem 38
- feat: problem 39
- fix: remove problem 39 cache
- chore: problem 40 wip
- chore(deps): bump actions/checkout from 2.4.0 to 3
- feat: problem 40
- feat: problem 41
- feat: problem 42
- feat: problem 43
- feat: problem 44
- feat: problem 45
- feat: problem 46
- feat: problem 48
- chore: made clearer
- feat: problem 49
- feat: problem 50
- feat: problem 51
- feat: problem 52
- feat: problem 53
- chore: clearified var name
- feat: problem 54
- feat: problem 55
- feat: problem 56
- feat: problem 57
- feat: problem 58
- feat: problem 59
- chore(deps): bump EnricoMi/publish-unit-test-result-action
- feat: problem 60
- feat: problem 63
- feat: problem 58
- chore: problem 64 foundation
- feat: problem 64
- feat: problem 65
- feat: problem 68
- feat: problem 72
- feat: problem 73
- feat: renamed dirs, added problems
- feat: problem 77 - 80
- feat: problem 81 - 83
- feat: problem 84 - 85
- feat: problem 86 - 87
- feat: problem 88 - 91
- feat: problem 91 - 92
- chore: cleaned up code
- chore: problem 93 foundation
- chore(deps-dev): bump prettier from 2.5.1 to 2.6.0
- chore: fixed unused var warning, ran rust fmt
- feat: problem 93
- feat: problem 94
- feat: problem 95 - 98
- fix: made code clearer
- feat: problem 95 - 98
- chore: create semgrep.yml
- chore: formatting
- chore: compare unordered
- chore: full sha
- chore: corrected sha
- feat: problem 316, 747, 895, 1705
- chore: formatting
- chore(deps): bump github/codeql-action
- chore(deps): bump returntocorp/semgrep-action
- chore(deps): bump actions/cache from 2.1.7 to 3
- chore: removed broken code
- feat: problem 1007
- chore: formatting
- chore: formatting
- chore: added update script
- feat: problem 1663
- feat: problem 0099
- chore: format code
- chore: format code
- chore: removed - from name
- fix: merge commit gone haywire
- fix: clippy 1.67
- chore(deps): update rust to v1.67.0
- chore(deps): update github/codeql-action action to v2.2.1
- chore(deps): update returntocorp/semgrep docker digest to 4a3ac0d
- chore(deps): update actions/cache action to v3.2.4
- chore(deps): update actions-rs-plus/clippy-check digest to b09a9c3
- chore(deps): update returntocorp/semgrep docker digest to 93d798a
- chore(deps): update returntocorp/semgrep docker digest to d7c4a86
- chore(deps): update actions-rs-plus/clippy-check digest to 11c2600
- chore(deps): update github/codeql-action action to v2.2.2
- chore(deps): update mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye docker digest to 2b1cc67
- chore(deps): update actions-rs-plus/clippy-check digest to 377c478
- chore(deps): update github/codeql-action action to v2.2.3
- chore(deps): update actions-rs-plus/clippy-check digest to 24949b2
- chore(deps): update returntocorp/semgrep docker digest to ffc6f35
- chore(deps): update actions/cache action to v3.2.5
- chore(deps): update rust to v1.67.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.4.1
- chore(deps): update github/codeql-action action to v2.2.4
- chore(deps): update returntocorp/semgrep docker digest to a645506
- chore(deps): update actions-rs-plus/clippy-check digest to 4837f9b
- chore(deps): update dependency prettier to ^2.8.4
- chore(deps): update node.js to >=v16.19.0
- chore(deps): update npm to >=8.19.3
- chore(deps): update returntocorp/semgrep docker digest to 7a9c18d
- chore(deps): update mcr.microsoft.com/vscode/devcontainers/rust:1-bullseye docker digest to 7eb80e1
- chore(deps): update npm to >=9.5.0
- chore(deps): update node.js to >=v18.14.1
- chore(deps): update returntocorp/semgrep docker digest to 23d35d2
- chore(deps): update actions/cache action to v3.2.6
- chore(deps): update node.js to >=v18.14.2
- chore: formatting
- chore(deps): update npm to >=9.5.1
- chore(deps): update returntocorp/semgrep docker tag to v1.13.0
- chore(deps): update github/codeql-action action to v2.2.5
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.4.2
- chore(deps): update returntocorp/semgrep docker tag to v1.14.0
- chore(deps): update npm to >=9.6.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to 3bef9bc
- chore(deps): update node.js to >=v18.15.0
- chore(deps): update npm to >=9.6.1
- chore(deps): update actions/cache action to v3.3.0
- chore(deps): update rust to v1.68.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to d034d73
- chore(deps): update docker/setup-buildx-action action to v2.5.0
- chore(deps): update github/codeql-action action to v2.2.6
- chore(deps): update actions/cache action to v3.3.1
- chore(deps): update github/codeql-action action to v2.2.7
- chore(deps): update actions/checkout action to v3.4.0
- chore(deps): update npm to >=9.6.2
- chore(deps): update returntocorp/semgrep docker tag to v1.15.0
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.5.0
- chore(deps): update dependency prettier to ^2.8.5
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.6.0
- chore(deps): update dependency prettier to ^2.8.6
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.6.1
- chore(deps): update github/codeql-action action to v2.2.8
- chore(deps): update dependency prettier to ^2.8.7
- chore(deps): update actions/checkout action to v3.5.0
- chore(deps): update github/codeql-action action to v2.2.9
- chore(deps): update rust to v1.68.1
- chore(deps): update rust to v1.68.2
- chore(deps): update npm to >=9.6.3
- chore(deps): update returntocorp/semgrep docker tag to v1.16.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to 601b3b8
- chore(deps): update returntocorp/semgrep docker tag to v1.17.0
- chore(deps): update github/codeql-action action to v2.2.10
- chore(deps): update npm to >=9.6.4
- chore(deps): update returntocorp/semgrep docker tag to v1.17.1
- chore(deps): update github/codeql-action action to v2.2.11
- chore(deps): update actions/github-script action to v6.4.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.6.2
- chore(deps): update codecov/codecov-action action to v3.1.2
- chore(deps): update actions/checkout action to v3.5.1
- chore(deps): update node.js to >=v18.16.0
- chore(deps): update github/codeql-action action to v2.2.12
- chore(deps): update actions/checkout action to v3.5.2
- chore(deps): update returntocorp/semgrep docker tag to v1.18.0
- chore(deps): update docker/metadata-action action to v4.4.0
- chore(deps): update npm to >=9.6.5
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.7.0
- fix: let _ requires type
- chore(deps): update codecov/codecov-action action to v3.1.3
- chore(deps): update rust to v1.69.0
- chore(deps): update returntocorp/semgrep docker tag to v1.19.0
- chore(deps): update github/codeql-action action to v2.3.0
- chore(deps): update dependency prettier to ^2.8.8
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to fdcde64
- chore(deps): update github/codeql-action action to v2.3.1
- chore(deps): update github/codeql-action action to v2.3.2
- chore(deps): update returntocorp/semgrep docker tag to v1.20.0
- chore(deps): update npm to >=9.6.6
- chore(deps): update github/codeql-action action to v2.3.3
- chore(deps): update returntocorp/semgrep docker tag to v1.21.0
- chore(deps): update codecov/codecov-action action to v3.1.4
- chore(deps): update returntocorp/semgrep docker tag to v1.22.0
- chore(deps): update npm to >=9.6.7
- chore(deps): update returntocorp/semgrep docker tag to v1.23.0
- chore(deps): update github/codeql-action action to v2.3.4
- chore(deps): update github/codeql-action action to v2.3.5
- chore(deps): update github/codeql-action action to v2.3.6
- chore(deps): update rust to v1.70.0
- chore(deps): update returntocorp/semgrep docker tag to v1.24.1
- chore(deps): update returntocorp/semgrep docker tag to v1.25.0
- chore(deps): update docker/login-action action to v2.2.0
- chore(deps): update docker/metadata-action action to v4.5.0
- chore(deps): update docker/setup-buildx-action action to v2.6.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to b723b13
- chore(deps): update npm to >=9.7.1
- chore(deps): update docker/build-push-action action to v4.1.0
- chore(deps): update actions/checkout action to v3.5.3
- chore(deps): update rust:1.70.0 docker digest to 508253a
- chore(deps): update dependency semantic-release to ^21.0.5
- chore(deps): update alpine docker tag to v3.18.2
- chore(deps): update alpine:3.18.2 docker digest to e13ce78
- chore(deps): update alpine:3.18.2 docker digest to c7431a7
- chore(deps): update alpine:3.18.2 docker digest to 5246eec
- chore(deps): update alpine:3.18.2 docker digest to 82d1e9d
- chore(deps): update mcr.microsoft.com/devcontainers/rust docker tag to v1
- chore(deps): update dependency semver to ^7.5.2
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^6.1.0
- chore(deps): lock file maintenance
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.8.0
- chore(deps): update node.js to >=v18.16.1
- chore(deps): update github/codeql-action action to v2.20.1
- chore(deps): update returntocorp/semgrep docker tag to v1.28.0
- chore(deps): update npm to >=9.7.2
- chore(deps): update dependency semver to ^7.5.3
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.29.0
- chore(deps): update returntocorp/semgrep docker tag to v1.30.0
- chore(deps): update docker/setup-buildx-action action to v2.8.0
- chore(deps): update dependency semantic-release to ^21.0.6
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.20.2
- chore(deps): update rust:1.70.0 docker digest to d3283ba
- chore(deps): update rust:1.70.0 docker digest to 28ee882
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.4
- chore(deps): update rust:1.70.0 docker digest to dbdf889
- chore(deps): update dependency semantic-release to ^21.0.7
- chore(deps): update actions/setup-node action to v3.7.0
- chore(deps): update npm to >=9.8.0
- chore(deps): update github/codeql-action action to v2.20.3
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to b732d41
- chore(deps): update dependency prettier to v3
- chore(deps): update docker/setup-buildx-action action to v2.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.31.1
- chore(deps): update returntocorp/semgrep docker tag to v1.31.2
- chore(deps): update dependency semver to ^7.5.4
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v2.9.1
- chore(deps): update rust to v1.71.0
- chore(deps): update returntocorp/semgrep docker tag to v1.32.0
- chore(deps): update github/codeql-action action to v2.20.4
