### PR TITLE
remove unneeded type annotations

### DIFF
--- a/src/problem_0026/mod.rs
+++ b/src/problem_0026/mod.rs
@@ -8,7 +8,7 @@ fn remove_duplicates(nums: &mut Vec<i32>) -> i32 {
 
         match n.cmp(&previous) {
             std::cmp::Ordering::Equal => {
-                let _: i32 = nums.remove(index);
+                let _ = nums.remove(index);
                 length -= 1;
             },
             std::cmp::Ordering::Greater => {

--- a/src/problem_0086/mod.rs
+++ b/src/problem_0086/mod.rs
@@ -6,7 +6,7 @@ fn add_to_end(head: &mut Option<Box<ListNode>>, to_add_to_end: Option<Box<ListNo
     while let Some(mut c) = current.take() {
         if c.next.is_none() {
             c.next = to_add_to_end;
-            let _: &mut Box<ListNode> = current.insert(c); // put it back
+            let _ = current.insert(c); // put it back
             break;
         }
 

--- a/src/problem_0114/mod.rs
+++ b/src/problem_0114/mod.rs
@@ -11,13 +11,13 @@ fn flatten(root: &mut Option<Rc<RefCell<TreeNode>>>) {
             match (b.left.take(), b.right.take()) {
                 (None, None) => {},
                 (Some(l), None) => {
-                    let _: &mut Rc<RefCell<TreeNode>> = b.right.insert(l);
+                    let _ = b.right.insert(l);
                 },
                 (None, Some(r)) => {
-                    let _: &mut Rc<RefCell<TreeNode>> = b.right.insert(r);
+                    let _ = b.right.insert(r);
                 },
                 (Some(l), Some(r)) => {
-                    let _: &mut Rc<RefCell<TreeNode>> = b.right.insert(l);
+                    let _ = b.right.insert(l);
 
                     let mut current = b.right.clone().unwrap();
 

--- a/src/problem_0155/mod.rs
+++ b/src/problem_0155/mod.rs
@@ -30,8 +30,8 @@ impl Solution {
 
         min_stack.push(1);
         min_stack.pop();
-        let _: i32 = min_stack.top();
-        let _: i32 = min_stack.get_min();
+        let _ = min_stack.top();
+        let _ = min_stack.get_min();
     }
 }
 

--- a/src/problem_0173/mod.rs
+++ b/src/problem_0173/mod.rs
@@ -40,8 +40,8 @@ impl BSTIterator {
 impl Solution {
     pub fn problem() {
         let mut iterator = BSTIterator::new(None);
-        let _: i32 = iterator.next();
-        let _: bool = iterator.has_next();
+        let _ = iterator.next();
+        let _ = iterator.has_next();
     }
 }
 

--- a/src/problem_0895/mod.rs
+++ b/src/problem_0895/mod.rs
@@ -35,8 +35,7 @@ impl FreqStack {
         // pop guaranteed by exercise
         let top = value.pop().unwrap();
 
-        let _: std::collections::hash_map::Entry<i32, i32> =
-            self.frequency_map.entry(top).and_modify(|v| *v -= 1);
+        let _ = self.frequency_map.entry(top).and_modify(|v| *v -= 1);
 
         if value.is_empty() {
             self.maximum_frequency -= 1;


### PR DESCRIPTION
- chore(deps): update dependency semantic-release to ^21.1.0
- chore(deps): update actions/checkout action to v3.6.0
- fix: clippy fixes
- chore(deps): update rust to v1.72.0
- fix: remove unneeded type annotations
