### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,15 +715,21 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
           while timeout --kill-after=70 60 docker buildx imagetools create "${new_tags[@]}" \
-            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}; [ $? = 124 ]; do
-            echo "Timeout exceeded, trying again..."
+            ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}; [[ ! $? -eq 0 ]]; do
+            echo "Timeout exceeded / command failed, trying again..."
 
             sleep 2
           done
 
+          echo "Process exited with: $?"
+
           for new_tag in $(echo "${{ join(steps.meta.outputs.tags, ' ') }}"); do
             echo "Inspecting ${new_tag}:"
-            docker buildx imagetools inspect --raw ${new_tag}
+            while timeout --kill-after=70 60 docker buildx imagetools inspect --raw ${new_tag}; [[ ! $? -eq 0 ]]; do
+              echo "Timeout exceeded / command failed, trying again..."
+
+              sleep 2
+            done
             # empty to get newline
             echo ""
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "leetcode"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2024"
-rust-version = "1.91.0"
+rust-version = "1.91.1"
 authors = ["Kristof Mattei"]
 description = "Leetcode"
 license = "MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.91.1"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update softprops/action-gh-release action to v2.4.2**
- **chore(deps): update pnpm to v10.21.0**
- **chore(deps): lock file maintenance**
- **fix: more timeout defense**
- **chore(deps): update rust docker tag to v1.91.1**
- **chore(deps): update rust to v1.91.1**
