### PR TITLE
update from upstream

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,15 +4,9 @@ disallowed-methods = [
     "serde_json::from_reader",
 ]
 disallowed-types = [
-<<<<<<< HEAD
     # doesn't apply in leetcode as we need to be able to paste it in in the online editor
     # { path = "std::collections::HashMap", replacement = "hashbrown::HashMap", reason = "The standard library version sacrificies performance for HashDos resistance, which should be chosen explicitly" },
     # { path = "std::collections::HashSet", replacement = "hashbrown::HashSet", reason = "The standard library version sacrificies performance for HashDos resistance, which should be chosen explicitly" },
-||||||| c2dc841d
-=======
-    { path = "std::collections::HashMap", replacement = "hashbrown::HashMap", reason = "The standard library version sacrificies performance for HashDos resistance, which should be chosen explicitly" },
-    { path = "std::collections::HashSet", replacement = "hashbrown::HashSet", reason = "The standard library version sacrificies performance for HashDos resistance, which should be chosen explicitly" },
->>>>>>> upstream/main
 ]
 enforced-import-renames = [
     { path = "serde_json::from_slice", rename = "from_json_slice" },


### PR DESCRIPTION
- **chore(deps): lock file maintenance**
- **chore(deps): update prettier (npm) to v3.7.0**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:2-1-bullseye docker digest to 867fc15**
- **chore(deps): update docker/metadata-action action to v5.10.0**
- **chore(deps): update prettier (npm) to v3.7.1**
- **chore(deps): update pnpm to v10.24.0**
- **chore(deps): update docker/setup-docker-action action to v4.6.0**
- **chore(deps): lock file maintenance**
- **chore(deps): lock file maintenance**
- **chore(deps): update prettier (npm) to v3.7.2**
- **chore(deps): update prettier (npm) to v3.7.3**
- **chore(deps): update softprops/action-gh-release action to v2.5.0**
- **chore(deps): update github/codeql-action action to v4.31.6**
- **chore(deps): update actions/checkout action to v6.0.1**
- **chore(deps): update prettier (npm) to v3.7.4**
- **chore(deps): update actions/setup-node action to v6.1.0**
- **chore(deps): update alpine docker tag to v3.23.0**
- **chore(deps): lock file maintenance**
- **chore(deps): update returntocorp/semgrep docker tag to v1.144.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.145.0**
- **chore(deps): update github/codeql-action action to v4.31.7**
- **feat: make clippy more strict**
- **chore: squash incoming commits, don't pollute history**
- **chore: back to the good old merge**
- **chore: restore script**
- **chore: bump packages**
