### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -744,6 +744,7 @@ jobs:
     name: Attest Docker container
     runs-on: ubuntu-latest
     permissions:
+      artifact-metadata: write
       attestations: write
       id-token: write
       packages: write


### PR DESCRIPTION
- **chore(deps): update github/codeql-action action to v4.31.9**
- **chore(deps): update returntocorp/semgrep docker tag to v1.146.0**
- **chore(deps): update alpine docker tag to v3.23.2**
- **chore(deps): update alpine:3.23.2 docker digest to 865b95f**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:2-1-bullseye docker digest to 3946a1a**
- **chore(deps): update pnpm to v10.26.1**
- **chore(deps): update actions/attest-build-provenance action to v3.1.0**
- **chore(deps): update enricomi/publish-unit-test-result-action action to v2.22.0**
- **chore(deps): update docker/setup-buildx-action action to v3.12.0**
- **chore: attestation needs `artifact-metadata: write`**
- **chore(deps): lock file maintenance**
