### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install libclang-dev should cargo-spellcheck be built from source
         shell: bash
         run: |
-          sudo apt install libclang-dev
+          sudo apt-get install libclang-dev
 
       - name: Install cargo-spellcheck to check the spelling
         uses: taiki-e/install-action@3f67faa728964808f52294a9cd15561b15550b28 # v2.67.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ WORKDIR /build
 
 RUN cargo init --name ${APPLICATION_NAME}
 
-COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
+COPY ./.cargo ./.cargo
+COPY ./Cargo.toml ./Cargo.lock ./
 
 RUN echo "fn main() {}" > ./src/build.rs
 


### PR DESCRIPTION
- **chore(deps): update taiki-e/install-action action to v2.67.6**
- **chore(deps): update taiki-e/install-action action to v2.67.8**
- **chore(deps): update taiki-e/install-action action to v2.67.9**
- **chore(deps): update taiki-e/install-action action to v2.67.10**
- **chore(deps): update taiki-e/install-action action to v2.67.11**
- **chore(deps): update pnpm to v10.28.2**
- **chore(deps): update taiki-e/install-action action to v2.67.13**
- **chore(deps): update actions/attest-build-provenance action to v3.2.0**
- **chore(deps): update github/codeql-action action to v4.32.0**
- **chore(deps): update taiki-e/install-action action to v2.67.14**
- **chore(deps): update taiki-e/install-action action to v2.67.15**
- **chore(deps): update alpine docker tag to v3.23.3**
- **chore(deps): update registry:3 docker digest to 6504067**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:2-1-bullseye docker digest to 483c5f6**
- **chore(deps): update docker/login-action action to v3.7.0**
- **chore(deps): update actions/cache action to v5.0.3**
- **chore(deps): roll back returntocorp/semgrep docker tag to v1.149.0**
- **chore(deps): update registry:3 docker digest to 6c5666b**
- **chore(deps): pin returntocorp/semgrep docker tag to b6a1bae**
- **chore(deps): update returntocorp/semgrep docker tag to v1.150.0**
- **fix: use apt-get instaed of apt, as we're not supposed to use apt in scripts**
- **chore(deps): update taiki-e/install-action action to v2.67.16**
- **chore(deps): update mcr.microsoft.com/devcontainers/rust:2-1-bullseye docker digest to e9ff1bd**
- **chore(deps): lock file maintenance**
- **chore(deps): update taiki-e/install-action action to v2.67.17**
- **chore(deps): update taiki-e/install-action action to v2.67.18**
- **chore(deps): update github/codeql-action action to v4.32.1**
- **chore(deps): update rust:1.93.0-slim-trixie docker digest to f3c3894**
- **chore(deps): update rust:1.93.0-slim-trixie docker digest to 9e03c5f**
- **chore(deps): update rust:1.93.0-slim-trixie docker digest to e2367a8**
- **chore(deps): update taiki-e/install-action action to v2.67.19**
- **chore(deps): update returntocorp/semgrep docker tag to v1.151.0**
- **fix: copying a directory copies the contents into the destination, so we have to repeat the name, meaning we cannot mix it with files**
- **fix: add .**
